### PR TITLE
Add: Contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,30 @@
+# Naming Conventions
+
+## Branch Naming Conventions
+Use standard nouns as prefix to categorize the branch
+
+- blog : The branch only includes blog related changes such as adding/editing a blog
+- feature : When a new feature is to be added such as dark mode to our website
+- bugfix/hotfix : The purpose is to simple fix a bug that has sipped in
+
+<br>
+
+- Along with this, the branch name should be precise, short and able to convey the objective of the branch
+- We'll follow the use of `/`(slash) delimiter between the category and branch motive
+- For example, if the goal is to add a blog on Elastic Search, the branch name can be- `blog/why-elastic-search` (Note how the description is hyphenated)
+
+### What to avoid:
+- Long names
+- Only numerals
+- Full sentences
+
+The above mentioned branches are meant to be short lived. The branches should be deleted as soon as the branch is merged to `main`.
+
+## PR Naming Convention
+- To keep a better track of blogs and filter them quickly, two things can be done:
+- Add a prefix `Blog: foo bar` to the title of the PR
+- Add the label `blog` to your PR
+
+## Commit messages convention
+- We'll follow category naming convention similar to what is explained for branches.
+- Here's a quick rundown - [Standard Terminology](https://gist.github.com/turbo/efb8d57c145e00dc38907f9526b60f17)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,19 +1,24 @@
 # Naming Conventions
 
 ## Branch Naming Conventions
-Use standard nouns as prefix to categorize the branch
+
+### Prefixes
+
+Use standard nouns as `prefix` to categorize the branch, e.g:
 
 - blog : The branch only includes blog related changes such as adding/editing a blog
 - feature : When a new feature is to be added such as dark mode to our website
 - bugfix/hotfix : The purpose is to simple fix a bug that has sipped in
 
-<br>
+### General naming guidelines:
 
-- Along with this, the branch name should be precise, short and able to convey the objective of the branch
+- The branch name should be short and able to convey the objective of the changes
 - We'll follow the use of `/`(slash) delimiter between the category and branch motive
-- For example, if the goal is to add a blog on Elastic Search, the branch name can be- `blog/why-elastic-search` (Note how the description is hyphenated)
+- Branch names shiuld be hyphenated, they should be in `lower-kebab-case`
+- For example, if the goal is to add a blog on Elastic Search, the branch name can be - `blog/why-elastic-search`
 
 ### What to avoid:
+
 - Long names
 - Only numerals
 - Full sentences
@@ -21,10 +26,12 @@ Use standard nouns as prefix to categorize the branch
 The above mentioned branches are meant to be short lived. The branches should be deleted as soon as the branch is merged to `main`.
 
 ## PR Naming Convention
+
 - To keep a better track of blogs and filter them quickly, two things can be done:
 - Add a prefix `Blog: foo bar` to the title of the PR
 - Add the label `blog` to your PR
 
 ## Commit messages convention
+
 - We'll follow category naming convention similar to what is explained for branches.
 - Here's a quick rundown - [Standard Terminology](https://gist.github.com/turbo/efb8d57c145e00dc38907f9526b60f17)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Use standard nouns as `prefix` to categorize the branch, e.g:
 - feature : When a new feature is to be added such as dark mode to our website
 - bugfix/hotfix : The purpose is to simple fix a bug that has sipped in
 
-### General naming guidelines:
+### Tips:
 
 - The branch name should be short and able to convey the objective of the changes
 - We'll follow the use of `/`(slash) delimiter between the category and branch motive

--- a/README.md
+++ b/README.md
@@ -11,3 +11,5 @@
 - `hugo new blog/article-name.md` to create new post
 - If you are adding images make sure they are optimized, we suggest something like `https://squoosh.app/`, images are stored in `static/images`
 - Commit in a new branch and create PR against `main` branch
+
+[Contributing Guidelines](./CONTRIBUTING.md)


### PR DESCRIPTION
This is an initial version only meant to cover the naming conventions that should be followed across the repository.

The purpose is to have a standard to be followed by devs and non-tech people alike.