### PR TITLE
Make email required and with correct format

### DIFF
--- a/layouts/partials/subscribe.html
+++ b/layouts/partials/subscribe.html
@@ -16,11 +16,14 @@
     <div id="subscription-form-input">
       <div class="row">
         <div class="col-lg-10 col-md-10 d-flex align-items-center">
-          <input aria-label="Input your email to subscribe to Incubyte"
-                 class="form-control"
-                 name="email"
-                 placeholder="name@email.com"
-                 type="text" />
+          <input
+            aria-label="Input your email to subscribe to Incubyte"
+            class="form-control"
+            name="email"
+            placeholder="name@email.com"
+            required
+            type="email"
+          />
         </div>
         <div class="col-lg-2 col-md-2 mt-xl-0 mt-lg-0 mt-md-0 mt-2">
           <input class="btn btn-primary" type="submit" value="Subscribe" />


### PR DESCRIPTION
## What did you do?

Original Author: @kartik-madhak 

- [x] Makes it such that people cannot submit empty or wrong email format while subscribing to our blogs

## Why did you do it?

- Why not?

Why were these changes made?

- Close CRM was seeing empty email values

## Screenshots (Please include if anything visual)

![Screenshot from 2023-09-21 15-07-38](https://github.com/incubyte/incubyte.github.io/assets/58913047/641e82d8-7ac5-49d8-8c20-723b061a74de)
![Screenshot from 2023-09-21 15-07-48](https://github.com/incubyte/incubyte.github.io/assets/58913047/ae1f4535-69cf-4e0d-a307-5a25d312ddd9)
![Screenshot from 2023-09-21 15-07-54](https://github.com/incubyte/incubyte.github.io/assets/58913047/e7eeacf9-92fc-43dc-9bfb-e3a582d368a2)

