### PR TITLE
bugfix: Update back link to use browser history

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -10,7 +10,7 @@
   <div class="container">
     <article class="row">
       <div class="col-lg-8 mx-auto">
-        <a class="back-link" href="{{.Site.BaseURL}}"
+        <a class="back-link" href="javascript:history.back()"
           ><strong>←</strong> Back to Blog</a
         >
         <img


### PR DESCRIPTION
## What did you do?

Please include a summary of the changes.

- [x] Fixes the "Back to Blog" link functionality.
- [x] Modified the href attribute in the HTML code.

## Why did you do it?

Why were these changes made?

- When reading through blog posts, returning to the previous page was difficult as the link always redirected to the site's homepage.

## Screenshots (Please include if anything visual)

https://github.com/user-attachments/assets/25d34fb1-b965-4f80-a3f7-355ce5dcaf71

