### PR TITLE
Fix error in share template

### DIFF
--- a/layouts/partials/share-buttons.html
+++ b/layouts/partials/share-buttons.html
@@ -1,13 +1,13 @@
 {{ $url := printf "%s" .Permalink | absLangURL }}
 {{ $textBody := print .Title "\n\n" (.Summary | truncate 200) "\n\n" $url "\n" }}
-{{ $encodedSummary := strings.TrimPrefix "=" (querify "" (.Summary | truncate 200))  }}
+{{ $urlWithParams := printf "https://www.linkedin.com/shareArticle?mini=true&url=%s" $url }}
 
 <h2>Consider Sharing!</h2>
 
 <div style="font-size: 80%">
 
     <a class="resp-sharing-button__link" href="https://www.facebook.com/sharer.php?u={{ $url }}&t={{ .Title }}"
-         target="_blank" rel="noopener" aria-label="Facebook">
+       target="_blank" rel="noopener" aria-label="Facebook">
         <div class="resp-sharing-button resp-sharing-button--facebook resp-sharing-button--medium">
             <div aria-hidden="true" class="resp-sharing-button__icon resp-sharing-button__icon--solidcircle">
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
@@ -20,8 +20,8 @@
     </a>
 
     <a class="resp-sharing-button__link"
-         href="https://twitter.com/share?text={{ .Title }}&url={{ $url }}&screen_name=incubyte_co"
-         target="_blank" rel="noopener" aria-label="Twitter">
+       href="https://twitter.com/share?text={{ .Title }}&url={{ $url }}&screen_name=incubyte_co"
+       target="_blank" rel="noopener" aria-label="Twitter">
         <div class="resp-sharing-button resp-sharing-button--twitter resp-sharing-button--medium">
             <div aria-hidden="true" class="resp-sharing-button__icon resp-sharing-button__icon--solidcircle">
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
@@ -34,8 +34,8 @@
     </a>
 
     <a class="resp-sharing-button__link"
-         href="mailto:?subject={{ .Title }}&body={{ $textBody }}"
-         target="_self" rel="noopener" aria-label="E-Mail">
+       href="mailto:?subject={{ .Title }}&body={{ $textBody }}"
+       target="_self" rel="noopener" aria-label="E-Mail">
         <div class="resp-sharing-button resp-sharing-button--email resp-sharing-button--medium">
             <div aria-hidden="true" class="resp-sharing-button__icon resp-sharing-button__icon--solidcircle">
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
@@ -50,13 +50,13 @@
     </a>
 
     <a class="resp-sharing-button__link"
-         href="https://www.linkedin.com/shareArticle?mini=true&url={{ $url }}&title={{ .Title }}&summary={{ $encodedSummary }}"
-         target="_blank" rel="noopener" aria-label="LinkedIn">
+       href="{{ $urlWithParams }}"
+       target="_blank" rel="noopener" aria-label="LinkedIn">
         <div class="resp-sharing-button resp-sharing-button--linkedin resp-sharing-button--medium">
             <div aria-hidden="true" class="resp-sharing-button__icon resp-sharing-button__icon--solidcircle">
                 <svg x="0px" y="0px" width="24px" height="24px" viewBox="0 0 24 24" xml:space="preserve">
         <path
-                    d="M12,0C5.383,0,0,5.383,0,12s5.383,12,12,12s12-5.383,12-12S18.617,0,12,0z M9.5,16.5h-2v-7h2V16.5z M8.5,7.5 c-0.553,0-1-0.448-1-1c0-0.552,0.447-1,1-1s1,0.448,1,1C9.5,7.052,9.053,7.5,8.5,7.5z M18.5,16.5h-3V13c0-0.277-0.225-0.5-0.5-0.5 c-0.276,0-0.5,0.223-0.5,0.5v3.5h-3c0,0,0.031-6.478,0-7h3v0.835c0,0,0.457-0.753,1.707-0.753c1.55,0,2.293,1.12,2.293,3.296V16.5z" />
+            d="M12,0C5.383,0,0,5.383,0,12s5.383,12,12,12s12-5.383,12-12S18.617,0,12,0z M9.5,16.5h-2v-7h2V16.5z M8.5,7.5 c-0.553,0-1-0.448-1-1c0-0.552,0.447-1,1-1s1,0.448,1,1C9.5,7.052,9.053,7.5,8.5,7.5z M18.5,16.5h-3V13c0-0.277-0.225-0.5-0.5-0.5 c-0.276,0-0.5,0.223-0.5,0.5v3.5h-3c0,0,0.031-6.478,0-7h3v0.835c0,0,0.457-0.753,1.707-0.753c1.55,0,2.293,1.12,2.293,3.296V16.5z" />
     </svg>
             </div>
             LinkedIn
@@ -64,8 +64,8 @@
     </a>
 
     <a class="resp-sharing-button__link"
-         href="https://reddit.com/submit?url={{ $url }}&title={{ .Title }}"
-         target="_blank" rel="noopener" aria-label="Reddit">
+       href="https://reddit.com/submit?url={{ $url }}&title={{ .Title }}"
+       target="_blank" rel="noopener" aria-label="Reddit">
         <div class="resp-sharing-button resp-sharing-button--reddit resp-sharing-button--medium">
             <div aria-hidden="true" class="resp-sharing-button__icon resp-sharing-button__icon--solidcircle">
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
@@ -84,8 +84,8 @@
     </a>
 
     <a class="resp-sharing-button__link"
-         href="whatsapp://send?text={{ $textBody }}"
-         target="_blank" rel="noopener" aria-label="WhatsApp">
+       href="whatsapp://send?text={{ $textBody }}"
+       target="_blank" rel="noopener" aria-label="WhatsApp">
         <div class="resp-sharing-button resp-sharing-button--whatsapp resp-sharing-button--medium">
             <div aria-hidden="true" class="resp-sharing-button__icon resp-sharing-button__icon--solidcircle">
                 <svg xmlns="http://www.w3.org/2000/svg" height="24" width="24" viewBox="0 0 24 24">


### PR DESCRIPTION
## What did you do?

- somehow there was error while rendering summary of articles in the linkedin share url. I removed that code since linkedin no longer supports the summary in the share url - https://stackoverflow.com/a/61856180

## Why did you do it?

Why were these changes made?

- This was missing
- that needed changes

## Screenshots (Please include if anything visual)

Include any relevant screenshots that may help explain the change.
