### PR TITLE
Dont show Posts title on authors list page

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -12,7 +12,7 @@
         </div>
         {{end}}
 
-        {{ if not (eq .Section "authors") }}
+        {{ if not (eq .RelPermalink "/authors/") }}
             <div class="display-4">Posts</div>
         {{ end }}
 

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -11,7 +11,11 @@
             </div>
         </div>
         {{end}}
-        <div class="display-4">Posts</div>
+
+        {{ if not (eq .Section "authors") }}
+            <div class="display-4">Posts</div>
+        {{ end }}
+
         <hr>
         <div class="row">
             {{ range first 1 (where .Data.Pages "Type" "featured") }}


### PR DESCRIPTION
## What did you do?
- Removed "Posts" title from Authors list page

![image](https://github.com/user-attachments/assets/199dd2ea-3790-47f7-b50c-87cf80bc4ed5)

![image](https://github.com/user-attachments/assets/9993fd26-363d-4d04-b06f-4f92af157dca)


https://blog.incubyte.co/authors/

Please include a summary of the changes.

- [x] Added this
- [ ] Updated that

## Why did you do it?

Why were these changes made?

- This was missing
- that needed changes

## Screenshots (Please include if anything visual)

Include any relevant screenshots that may help explain the change.
