### PR TITLE
Dont show By and Date for Author Card on Author list page

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -56,7 +56,7 @@
                         <p class="card-text">{{ .Summary | truncate 120 "..." }} </p>
                         {{ if not (eq .Section "authors") }}
                             <p class="blockquote-footer text-right">
-                                By {{range .Params.authors}}
+                                By {{ range .Params.authors }}
                                 <a href="/authors/{{ . | urlize }}">{{ . }}</a>, {{ end }} on {{
                                 .Date.Format "January 2, 2006"}}
                             </p>

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -54,11 +54,13 @@
                         <span class="badge rounded-pill bg-dark"> <a class="text-white" href="/tags/{{ . | urlize }}">{{ . }}</a></span>
                         {{ end }}
                         <p class="card-text">{{ .Summary | truncate 120 "..." }} </p>
-                        <p class="blockquote-footer text-right">
-                            By {{range .Params.authors}}
-                            <a href="/authors/{{ . | urlize }}">{{ . }}</a>, {{ end }} on {{
-                            .Date.Format "January 2, 2006"}}
-                        </p>
+                        {{ if not (eq .Section "authors") }}
+                            <p class="blockquote-footer text-right">
+                                By {{range .Params.authors}}
+                                <a href="/authors/{{ . | urlize }}">{{ . }}</a>, {{ end }} on {{
+                                .Date.Format "January 2, 2006"}}
+                            </p>
+                        {{ end }}
                     </div>
                 </article>
             </div>


### PR DESCRIPTION
## What did you do?
- Not showing By and Date for Author Card on Authors List page
https://blog.incubyte.co/authors/

![image](https://github.com/user-attachments/assets/6effe4d3-fe81-40bf-bd6d-4565baca443e)

![image](https://github.com/user-attachments/assets/1adea321-75d6-438a-a51a-28af3a3a5d99)



Please include a summary of the changes.

- [x] Added this
- [ ] Updated that

## Why did you do it?

Why were these changes made?

- This was missing
- that needed changes

## Screenshots (Please include if anything visual)

Include any relevant screenshots that may help explain the change.
