### PR TITLE
Dont show posts title on tag list

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -12,7 +12,7 @@
         </div>
         {{end}}
 
-        {{ if not (eq .RelPermalink "/authors/") }}
+        {{ if not (or (eq .RelPermalink "/authors/") (eq .RelPermalink "/tags/")) }}
             <div class="display-4">Posts</div>
         {{ end }}
 


### PR DESCRIPTION
## What did you do?
- Dont show "Posts" title on tags list
https://blog.incubyte.co/tags/

![image](https://github.com/user-attachments/assets/64cc46d2-a90d-43f2-a853-d968ce6cac80)


Please include a summary of the changes.

- [] Added this
- [x] Updated that

## Why did you do it?

Why were these changes made?

- This was missing
- that needed changes

## Screenshots (Please include if anything visual)

Include any relevant screenshots that may help explain the change.
