### PR TITLE
Dont show By and Date for Tag in Tag list

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -54,7 +54,7 @@
                         <span class="badge rounded-pill bg-dark"> <a class="text-white" href="/tags/{{ . | urlize }}">{{ . }}</a></span>
                         {{ end }}
                         <p class="card-text">{{ .Summary | truncate 120 "..." }} </p>
-                        {{ if not (eq .Section "authors") }}
+                        {{ if not (or (eq .Section "authors") (eq .Section "tags")) }}
                             <p class="blockquote-footer text-right">
                                 By {{range .Params.authors}}
                                 <a href="/authors/{{ . | urlize }}">{{ . }}</a>, {{ end }} on {{


### PR DESCRIPTION
## What did you do?
- Dont show By and Date for Tag Card in Tag List
https://blog.incubyte.co/tags/

![image](https://github.com/user-attachments/assets/3455929e-819e-444d-947d-86581067f193)
![image](https://github.com/user-attachments/assets/72fd1d59-01db-4f5c-8d09-69163fc806e5)


Please include a summary of the changes.

- [] Added this
- [X] Updated that

## Why did you do it?

Why were these changes made?

- This was missing
- that needed changes

## Screenshots (Please include if anything visual)

Include any relevant screenshots that may help explain the change.
