### PR TITLE
fix: Render initials avatar for authors without a photo

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -47,13 +47,24 @@
                     <a href="{{.Permalink}}">
                         <img src="{{ .Params.image |relURL }}" alt="{{ .Title }}" class="mb-1 card-img rounded-lg mb-4">
                     </a>
+                    {{ else if eq .Section "authors" }}
+                    {{/* Authors are a taxonomy, so a term page exists for every name used in a post.
+                         Until someone adds content/authors/<slug>/_index.md there is no photo, so fall
+                         back to their initials instead of rendering an empty card. */}}
+                    {{ $initials := "" }}
+                    {{ range (split .Title " ") }}{{ if . }}{{ $initials = printf "%s%s" $initials (substr . 0 1) }}{{ end }}{{ end }}
+                    <a href="{{.Permalink}}" class="card-img avatar-placeholder rounded-lg mb-4" aria-label="{{ .Title }}">
+                        <span aria-hidden="true">{{ substr $initials 0 2 | upper }}</span>
+                    </a>
                     {{ end }}
                     <div class="card-body p-0">
                         <h3><a href="{{ .Permalink }}" title="{{ .Title }}" class="post-title">{{ .Title }}</a></h3>
                         {{ range .Params.tags }}
                         <span class="badge rounded-pill bg-dark"> <a class="text-white" href="/tags/{{ . | urlize }}">{{ . }}</a></span>
                         {{ end }}
-                        <p class="card-text">{{ .Summary | truncate 120 "..." }} </p>
+                        {{ with .Summary }}
+                        <p class="card-text">{{ . | truncate 120 "..." }} </p>
+                        {{ end }}
                         {{ if not (or (eq .Section "authors") (eq .Section "tags")) }}
                             <p class="blockquote-footer text-right">
                                 By {{ range .Params.authors }}

--- a/layouts/partials/style.html
+++ b/layouts/partials/style.html
@@ -179,6 +179,27 @@ resources.Concat "/css/style.css" | minify | fingerprint "sha512"}}
     min-height: 180px;
   }
 
+  /* Initials shown when an author has no photo yet */
+  .avatar-placeholder {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 180px;
+    background-color: #12375a;
+    color: #fff;
+    font-family: 'Nunito Sans', sans-serif;
+    font-weight: 700;
+    font-size: 3.5rem;
+    letter-spacing: 0.05em;
+    text-decoration: none;
+  }
+
+  .avatar-placeholder:hover,
+  .avatar-placeholder:focus {
+    color: #fff;
+    filter: brightness(1.15);
+  }
+
   .display-3 {
     text-align: left;
   }
@@ -343,6 +364,10 @@ resources.Concat "/css/style.css" | minify | fingerprint "sha512"}}
 
   body.dark-theme .card {
     background-color: var(--extra-dark-background);
+  }
+
+  body.dark-theme .avatar-placeholder {
+    background-color: var(--app-primary);
   }
 
   body.dark-theme .display-5,


### PR DESCRIPTION
author is a taxonomy, so Hugo generates a term page for every name listed in a post's authors. Only 12 of the 37 authors have a content/authors/<slug>/_index.md, so the remaining 25 had no image and no .Summary and rendered as empty grey boxes on /authors/, with mismatched card heights breaking the grid.

Fall back to the author's initials when there is no photo, and skip the bio paragraph when there is no summary. The initials branch is scoped to the authors section, so /tags/ and the blog listing are unchanged.

What did you do?

Please include a summary of the changes.

- [x] Added an initials-avatar fallback in layouts/_default/list.html for author cards with no image, scoped to eq .Section "authors"
- [x] Wrapped the bio paragraph in {{ with .Summary }} so bio-less authors no longer emit an empty <p class="card-text">
- [x] Added .avatar-placeholder styles in layouts/partials/style.html, sized to match .card-img (min-height: 180px), with a dark-theme variant using the existing --app-primary

Why did you do it?

Why were these changes made?

- 25 of 37 authors had no profile page, so their cards rendered as bare headings inside stretched card backgrounds
- Card heights no longer matched, which broke the row layout on /authors/
- The page broke every time a new author published before their profile existed — this makes it degrade gracefully instead
- Adding the missing photos and bios is still a worthwhile follow-up; this change stops the page from breaking in the meantime

Screenshots (Please include if anything visual)

<img width="1866" height="856" alt="image" src="https://github.com/user-attachments/assets/69a4827a-6555-41d2-bc90-fa66610066ce" />
